### PR TITLE
Fix package.json, breaks at least on ember-cli@3.15

### DIFF
--- a/packages/@css-blocks/ember-cli/package.json
+++ b/packages/@css-blocks/ember-cli/package.json
@@ -57,16 +57,12 @@
     "ember-try": "^1.1.0",
     "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.0",
-    "in-repo-addon": "link:./tests/dummy/lib/in-repo-addon",
-    "in-repo-engine": "link:./tests/dummy/lib/in-repo-engine",
-    "in-repo-lazy-engine": "link:./tests/dummy/lib/in-repo-lazy-engine",
     "loader.js": "^4.7.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel",
       "ember-cli-htmlbars"
@@ -74,11 +70,6 @@
     "after": [
       "ember-cli-sass",
       "ember-cli-eyeglass"
-    ],
-    "paths": [
-      "tests/dummy/lib/in-repo-addon",
-      "tests/dummy/lib/in-repo-engine",
-      "tests/dummy/lib/in-repo-lazy-engine"
     ]
   },
   "volta": {


### PR DESCRIPTION
Test folders are not there and ember-cli@3.15.1 fails silently when checking the addon.